### PR TITLE
Replace Splunk password auth with token auth

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -8,7 +8,21 @@ The Splunk environment integration consists of two pieces:  receipt of a webook,
 
 Initial development was done with a CURL to the CAR running locally to simulate the webhook, and a contaier running an HTTP server that responsed with a mock Splunk search result.
 
-TODO: There needs to be a better way to test these integrations.
+As of this writing, Splunk doesn't offer a free development environment in the same way Atlassian does, so testing sending of a webhook still need sto be done with a manual CURL to your local CAR instance.  However, all of the search retrieval operations are read-only, so it's not totally unreasonable to use a real Splunk instances for development.
+
+For SplunkCloud, someone with Admin privileges needs to setup a user account and request a bearer token from Splunk. Note that for SplunkCloud, API access has to be requested from Splunk, to allow a set of IP addresses.
+
+1. Login to SplunkCloud, and select "Settings -> User"
+2. Create a user using "Splunk" authentication, and assign the desired roles. These should likely just be read-only access to the Search app results and indexes.
+3. Go to "Settings -> Tokens" and create a token for the new user.
+
+You can test your API token by curling the search endpoint:
+
+```shell
+curl -H "Authorization: Bearer your_api_token" \
+   -X GET \
+   https://your.instance.url:8089/services/search/v2
+```
 
 ### Setup Splunk config for CAR
 
@@ -17,9 +31,31 @@ This is currently unused for development.  The Splunk config should look somethi
 ```yaml
 splunkconfig:
   host: https://your_splunk_server:port
-  username: your_splunk_username
-  password: your_splunk_password
+  token: your_splunk_token
   allowinsecure: false
+```
+
+### From Webhook to Search Results
+
+Concepts:
+
+1. Splunk alerts are just Splunk Searches that run on some schedule.  The alert fires of the search turns up a set of results.
+2. The Splunk webhook will send the ID of a specific search + job for the alert that fires.
+3. The results of the search can be retrieved from the Splunk API with the search id ("search_id" in Splunk-API speak).  The search id will look something like `scheduler_abcdefg0123456789__search__RMDabcdefg0123456789_at_1674590400_80909`
+
+Retrieval of the search id from the webhook is trivial.
+
+Retrieval of the results of the search can be done by via the API: `https://your_splunk_server:port/services/search/v2/jobs/{search_id}/results`.  The results will return, among other data, an array of `results[]`, containing a representation of the hits for that particular search.  Each of the results in the array represent a specific audit alert to be triaged by the Compliance Audit Router - eg. each element in the array should turn into a specific ticket for audit purposes.
+
+Note: The format/contents of the elements in the search results array depend on the format of the search output, and are not guaranteed to be identical across different searches, so for multiple types of alerts, the output for each must be standardized.
+
+An example curl retrieving search results in JSON format looks something like this:
+
+```shell
+curl -H "Authorization: Bearer $(jq -r .token .splunk_api )" \
+     -X GET \
+     -d output_mode=json \
+     https://your_splunk_server:port/services/search/v2/jobs/scheduler_foobarbaz__search__RMDfoobarbaz_at_1674590400_80909/results
 ```
 
 ## LDAP

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -8,7 +8,7 @@ The Splunk environment integration consists of two pieces:  receipt of a webook,
 
 Initial development was done with a CURL to the CAR running locally to simulate the webhook, and a contaier running an HTTP server that responsed with a mock Splunk search result.
 
-As of this writing, Splunk doesn't offer a free development environment in the same way Atlassian does, so testing sending of a webhook still need sto be done with a manual CURL to your local CAR instance.  However, all of the search retrieval operations are read-only, so it's not totally unreasonable to use a real Splunk instances for development.
+As of this writing, Splunk doesn't offer a free development environment in the same way Atlassian does, so testing sending of a webhook still needs to be done with a manual CURL to your local CAR instance.  However, all of the search retrieval operations are read-only, so it's not totally unreasonable to use a real Splunk instances for development.
 
 For SplunkCloud, someone with Admin privileges needs to setup a user account and request a bearer token from Splunk. Note that for SplunkCloud, API access has to be requested from Splunk, to allow a set of IP addresses.
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ ldapconfig:
 
 splunkconfig:
   host: https://splunk.example.org:8089
-  username: <username>
-  password: <password>
+  token: <token>
   allowinsecure: false
 
 jiraconfig:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -56,8 +56,7 @@ type LDAPConfig struct {
 
 type SplunkConfig struct {
 	Host          string
-	Username      string
-	Password      string
+	Token         string
 	AllowInsecure bool
 }
 
@@ -102,8 +101,7 @@ func init() {
 		&AppConfig.LDAPConfig.Host,
 		&AppConfig.JiraConfig.Host,
 		&AppConfig.SplunkConfig.Host,
-		&AppConfig.SplunkConfig.Username,
-		&AppConfig.SplunkConfig.Password,
+		&AppConfig.SplunkConfig.Token,
 	} {
 		_, err := url.Parse(*x)
 		if err != nil {

--- a/pkg/splunk/splunk.go
+++ b/pkg/splunk/splunk.go
@@ -95,11 +95,8 @@ func RetrieveSearchFromAlert(sid string) (Alert, error) {
 		return alert, err
 	}
 
-	// REALLY, Splunk?
-	req.SetBasicAuth(
-		config.AppConfig.SplunkConfig.Username,
-		config.AppConfig.SplunkConfig.Password,
-	)
+	bearerToken := "Bearer" + config.AppConfig.SplunkConfig.Token
+	req.Header.Add("Authorization", bearerToken)
 
 	resp, err := splunkHttpClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
Replaces password auth with token auth for the Splunk API:

* Updated config parsing for tokens, removing username and password
* Updated Splunk pkg code to connect via Bearer token
* Updated README.md and DEVELOPMENT.md with token info