### PR TITLE
Adds local editor config (.vscode) to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ WEBHOOK
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
+# Editor config
+.vscode/
 
 # Temp
 Dockerfile


### PR DESCRIPTION
This adds the Visual Studio Code local config directory (.vscode/) to the
repository .gitignore file.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
