### PR TITLE
Removes unused test for listener creation

### DIFF
--- a/pkg/listeners/listeners_test.go
+++ b/pkg/listeners/listeners_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package listeners
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -31,42 +30,6 @@ func TestListenerURIs(t *testing.T) {
 		if err != nil {
 			t.Errorf("%s is not a valid url", l.Path)
 		}
-	}
-}
-
-func TestCreateListener(t *testing.T) {
-	tests := []Listener{
-		{
-			Path:    "/testListener01",
-			Methods: []string{http.MethodGet},
-			HandlerFunc: http.HandlerFunc(
-				func(w http.ResponseWriter, r *http.Request) {
-					w.WriteHeader(http.StatusOK)
-					w.Write([]byte("test"))
-				},
-			),
-		},
-		{
-			Path:    "/testListener02",
-			Methods: []string{http.MethodGet, http.MethodPost},
-			HandlerFunc: http.HandlerFunc(
-				func(w http.ResponseWriter, r *http.Request) {
-					w.WriteHeader(http.StatusOK)
-					w.Write([]byte("test"))
-				},
-			),
-		},
-	}
-
-	for _, tt := range tests {
-		testname := fmt.Sprintf("%s %s", strings.Join(tt.Methods, "_"), tt.Path)
-		t.Run(testname, func(t *testing.T) {
-			l := CreateListener(tt.Path, tt.Methods, tt.HandlerFunc)
-			if &tt.HandlerFunc == &l.Func {
-				t.Errorf("expected %v, got %v", tt.HandlerFunc, l.Func)
-			}
-		})
-
 	}
 }
 


### PR DESCRIPTION
This removes an unused test for listener creation that has been
obsoleted by Alex's simplification of the code in PR #4.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
