### PR TITLE
Minor fix for bug introduced by Alerts refactor

### DIFF
--- a/pkg/listeners/listeners.go
+++ b/pkg/listeners/listeners.go
@@ -87,7 +87,7 @@ func ProcessAlertHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Println("Received alert from Splunk:", alert.Sid, alert.Result.Raw)
+	log.Println("Received alert from Splunk:", alert.Sid)
 
 	// searchResults, err := splunk.RetrieveSearchFromAlert(alert.Sid)
 	// if err != nil {


### PR DESCRIPTION
This removes the logline print from listerns.go of the Alert.Result.Raw field, which no
longer exists after #10.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
