### PR TITLE
Add jira integration

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -95,7 +95,7 @@ curl -D- \
 
 You should receive a 200 response with an empty project result, as nothing exists in your Jira instance yet.
 
-### Create an Project in your instance
+### Create a Project in your instance
 
 First retrieve your account id (note the `emailAddress` filter in the JQ command below):
 
@@ -118,14 +118,38 @@ curl -u your_email@example.org:your_api_token \
 
    This will leave you with a project that you can then tweak to configure to match your production instance.
 
+### Enabling Permissions for your project
+Before you can create and manage new issues in your test project, you will need to add yourself to the Administrators role for your cloud account. To do this, use the following steps:
+
+1. While logged in to your JIRA cloud web console, click the menu button in the top-left and switch to the "Administration" service.
+1. Select "Directory" from the top tabs.
+1. Select "Groups" from the left sidebar.
+1. Find the group `jira-admins-YOUR_ACCOUNT_NAME` and click "Show Details" for the group.
+1. Click "Add Group Members" and add your account as a User to the group.
+
 ### Setup Jira config for CAR
 
-Add your test instance credentials to your `~/compliance-audit-router/compliance-audit-router.yaml` file:
+Add your test instance credentials and other required fields to your `~/compliance-audit-router/compliance-audit-router.yaml` file:
 
+- host - the url for your JIRA instance
+- username - your JIRA username
+- token - your API token or personal access token
+- key - the project key for which issues will be created
+- issuetype - the type to assign to created issues
+- dev - whether CAR is being run in a development environment.
+  - Note: this setting will assume that you are using a Jira Cloud instance with Basic Auth
+- transitions - map of what state to transition a ticket to after a specific user comments on the ticket. The ticket will only be transitioned if that user is also the ticket's current assignee. Note that "initial" is the initial state a ticket will be placed in after it is created.
 ```yaml
 ---
 jiraconfig:
   host: https://your.instance.url
   username: your_email@example.org
   token: your_api_token
+  key: OHSS
+  issuetype: Task
+  dev: true
+  transitions:
+    initial: In Progress
+    sre: Pending Approval
+    manager: Done
 ```

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/openshift/compliance-audit-router
 go 1.20
 
 require (
-	github.com/andygrunwald/go-jira v1.14.1-0.20211221102021-3b2368d4cbfc
+	github.com/andygrunwald/go-jira v1.16.0
 	github.com/go-chi/chi/v5 v5.0.8
 	github.com/go-ldap/ldap v3.0.3+incompatible
 	github.com/golang/gddo v0.0.0-20210115222349-20d68f94ee1f
@@ -13,8 +13,7 @@ require (
 require (
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
-	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
-	github.com/google/go-cmp v0.5.8 // indirect
+	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/andygrunwald/go-jira v1.14.1-0.20211221102021-3b2368d4cbfc h1:n0/OhUg76Ymb15quVgfd0I+JIxgX0Q3fzTIXGX98Jvc=
-github.com/andygrunwald/go-jira v1.14.1-0.20211221102021-3b2368d4cbfc/go.mod h1:75narbqNXpErEb+YMik5d3R5elyL/YxINhz6Sqjtkjo=
+github.com/andygrunwald/go-jira v1.16.0 h1:PU7C7Fkk5L96JvPc6vDVIrd99vdPnYudHu4ju2c2ikQ=
+github.com/andygrunwald/go-jira v1.16.0/go.mod h1:UQH4IBVxIYWbgagc0LF/k9FRs9xjIiQ8hIcC6HfLwFU=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -97,8 +97,8 @@ github.com/go-ldap/ldap v3.0.3+incompatible/go.mod h1:qfd9rJvER9Q0/D/Sqn1DfHRoBp
 github.com/go-stack/stack v1.6.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang-jwt/jwt/v4 v4.2.0 h1:besgBTC8w8HjP6NzQdxwKH9Z5oQMZ24ThTrHp3cZ8eU=
-github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
+github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
+github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/gddo v0.0.0-20210115222349-20d68f94ee1f h1:16RtHeWGkJMc80Etb8RPCcKevXGldr57+LOyZt8zOlg=
 github.com/golang/gddo v0.0.0-20210115222349-20d68f94ee1f/go.mod h1:ijRvpgDJDI262hYq/IQVYgf8hd8IHUs93Ol0kvMBAx4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -473,6 +473,7 @@ golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -64,7 +64,11 @@ type JiraConfig struct {
 	Host          string
 	AllowInsecure bool
 	Token         string
-	Query         string
+	Username      string
+	Key           string
+	IssueType     string
+	Dev           bool
+	Transitions   map[string]string
 }
 
 func init() {

--- a/pkg/ldap/ldap.go
+++ b/pkg/ldap/ldap.go
@@ -91,7 +91,7 @@ func LookupUser(username string) (string, string, error) {
 	var ldapManager string
 
 	if len(result.Entries) == 0 {
-		return "", "", errors.New("User not found")
+		return "", "", errors.New("user not found")
 	} else if len(result.Entries) > 1 {
 		return "", "", errors.New("multiple ldap entries found, please check your ldap config")
 	} else {


### PR DESCRIPTION
After processing a splunk webhook and looking up the user/manager in LDAP, a new ticket will be created in Jira based on the parameters in the config file.

- Ticket Summary: will always be `Compliance Alert: SRE Cluster Admin Elevation` as of right now, but open to making this a config property

- Ticket Description: I'll need to know what our splunk webhooks look like to finish this off, but there's sample text for now.

- Ticket Labels: Each created ticket will get three labels:
  - `compliance-audit-router-managed`: this signifies that CAR is managing the tickets. It also has the added benefit that we can set up the Jira webhook scope with very simple JQL of `labels = compliance-audit-router-managed` 
  - `compliance-audit-router/manager:<manager_account_id>`: the Jira account ID of the manager, or "unknown" if there was an issue looking them up. This allows us to quickly look up the manager for reassignment after the SRE has left a comment.
  - `compliance-audit-router/sre:<sre_account_id>`: same as above, just for the SRE. This lets us know that the correct person has left a comment on the ticket to move it along in the process

- Assignee: The created ticket will initially be assigned to the SRE for whom the ticket was created

- Reporter: Will always be "self", or whatever individual/service is running CAR

- Type: This is configurable now, likely "Incident" or "Task"

- Project: The key for the project in Jira (i.e. OHSS). Also now configurable.

Instantly after creating the ticket, a comment will be left on the ticket using `messageTemplate` in the config. Currently, a `{{.Username}}` template variable can be populated.

After this, we assume that a Jira webhook is set up to call the new endpoint `/api/v1/jira_webhook` whenever a new comment is left on a ticket with the `compliance-audit-router-managed` label. CAR will then check if the comment is from the current assignee, and if then use the ticket's labels to check if that user is the SRE or manager. After that, CAR will move the ticket to the proper status based on who the comment was from, which is now configured under `.jiraconfig.transitions`.