### PR TITLE
Add build output directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ WEBHOOK
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# Build output
+build/_output/
+
 # Certs or keys
 *.key
 *.crt


### PR DESCRIPTION
Adds build output directory to .gitignore

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
