### PR TITLE
Adds helper to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,3 +57,8 @@ $(BINARY_FILE): $(GO_SOURCES)
 .PHONY: boilerplate-update
 boilerplate-update:
 	@boilerplate/update
+
+# Just a helper to list all available make targets
+.PHONY: list
+list:
+	@LC_ALL=C $(MAKE) -pRrq -f $(firstword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/(^|\n)# Files(\n|$$)/,/(^|\n)# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | grep -E -v -e '^[^[:alnum:]]' -e '^$@$$'


### PR DESCRIPTION
Adds helper target to list make targets to the Makefile.

Usage:

```
$ make list
egrep: warning: egrep is obsolescent; using grep -E
all
boilerplate-commit
boilerplate-freeze-check
boilerplate-update
build
build/_output/compliance-audit-router
clean
default
isclean
osd-container-image-build
osd-container-image-build-push
osd-container-image-build-push-one
osd-container-image-login
osd-container-image-push
prow-config
serve
test
vet
```

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
