### PR TITLE
adds flag to disable LDAP lookups

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -43,10 +43,14 @@ func main() {
 	}
 
 	if config.AppConfig.Verbose {
-		log.Printf("verbose:    %t", config.AppConfig.Verbose)
-		log.Printf("splunkHost: %s", config.AppConfig.SplunkConfig.Host)
-		log.Printf("ldapHost:   %s", config.AppConfig.LDAPConfig.Host)
-		log.Printf("jiraHost:   %s", config.AppConfig.JiraConfig.Host)
+		log.Printf("verbose:     %t", config.AppConfig.Verbose)
+		log.Printf("ldapEnabled: %t", config.AppConfig.LDAPConfig.Enabled)
+
+		if config.AppConfig.LDAPConfig.Enabled {
+			log.Printf("ldapHost:    %s", config.AppConfig.LDAPConfig.Host)
+		}
+		log.Printf("splunkHost:  %s", config.AppConfig.SplunkConfig.Host)
+		log.Printf("jiraHost:    %s", config.AppConfig.JiraConfig.Host)
 	}
 
 	var portString = ":" + fmt.Sprint(config.AppConfig.ListenPort)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -57,6 +57,7 @@ type LDAPConfig struct {
 	SearchBase         string
 	Scope              string
 	Attributes         []string
+	Enabled            bool
 }
 
 type SplunkConfig struct {


### PR DESCRIPTION
- add dry run
- makes minor linter changes
- adds verbose logging; moves logging before metrics for better tracing
- finalize dry-run for processAlertHandler
- add template validation test on startup
- add more verbose output to main.go
- add error handling for failed splunk search; move verbose logging
- add more details on splunk api access to DEVELOPMENT.md
- fix incorrect number of arguments to metric creation
- handle case for empty "reason" field
- fix splunk alert retrieval url and bearer auth
- fixing splunk alert payload example path
- add return for HandleUpdate dryrun
- adds flag to disable LDAP lookups
