### PR TITLE
[OSD-21823] Properly parse alert details to Jira ticket body

### DIFF
--- a/pkg/listeners/listeners.go
+++ b/pkg/listeners/listeners.go
@@ -250,7 +250,7 @@ func ProcessAlertHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Create a Jira issue for the compliance event
-		jiraCreateErr := jira.CreateTicket(jiraClient.User, jiraClient.Issue, user, manager, complianceEvent.AlertName)
+		jiraCreateErr := jira.CreateTicket(jiraClient.User, jiraClient.Issue, user, manager, complianceEvent.Body())
 		if jiraCreateErr != nil {
 			log.Printf("failed creating Jira ticket: %s", jiraCreateErr.Error())
 			metrics.MetricJiraIssueCreateFailures.With(p.LabelInput()).Inc()

--- a/pkg/splunk/alert.go
+++ b/pkg/splunk/alert.go
@@ -1,15 +1,22 @@
 package splunk
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 // AlertDetails is a structured Splunk alert details
 type AlertDetails struct {
-	AlertName  string
-	User       string
-	Group      string
-	Timestamp  time.Time
-	ClusterIDs []string
-	Reasons    []string
+	AlertName           string
+	User                string
+	Group               string
+	Timestamp           time.Time
+	ClusterIDs          []string
+	ClusterText         string
+	ElevatedSummary     []string
+	ElevatedSummaryText string
+	Reasons             []string
+	ReasonsText         string
 }
 
 // AlertDetails.Valid checks whether an alert has all the necessary fields for a compliance ticket
@@ -17,15 +24,37 @@ func (a AlertDetails) Valid() bool {
 	return a.AlertName != "" && a.User != "" && a.Group != "" && len(a.ClusterIDs) > 0
 }
 
+func (a AlertDetails) Name() string {
+	return a.AlertName
+}
+
+func (a AlertDetails) Body() string {
+	var s strings.Builder
+
+	s.WriteString(a.User + " - " + a.Name())
+	s.WriteString("\n\n")
+	s.WriteString(a.ClusterText)
+	s.WriteString("\n\n")
+	s.WriteString(a.ElevatedSummaryText)
+	s.WriteString("\n\n")
+	s.WriteString(a.ReasonsText)
+
+	return s.String()
+}
+
 // NewAlertDetails creates a new AlertDetails from a SearchResult
 func NewAlertDetails(result SearchResult) AlertDetails {
 	return AlertDetails{
-		AlertName:  result.string("alertname"),
-		User:       result.string("username"),
-		Group:      result.string("group"),
-		Timestamp:  result.time("timestamp"),
-		ClusterIDs: result.slice("clusterid"),
-		Reasons:    result.slice("reason"),
+		AlertName:           result.string("alertname"),
+		User:                result.string("username"),
+		Group:               result.string("group"),
+		Timestamp:           result.time("timestamp"),
+		ClusterIDs:          result.slice("clusterid"),
+		ClusterText:         result.string("cluster_text"),
+		ElevatedSummary:     result.slice("elevated_summary"),
+		ElevatedSummaryText: result.string("elevated_summary_text"),
+		Reasons:             result.slice("reason"),
+		ReasonsText:         result.string("reason_text"),
 	}
 }
 

--- a/pkg/splunk/result.go
+++ b/pkg/splunk/result.go
@@ -28,7 +28,9 @@ func (a SearchResult) slice(field string) []string {
 		case []string:
 			values = append(values, v...)
 		case []interface{}:
-			values = append(values, fmt.Sprint(v...))
+			for _, e := range v {
+				values = append(values, e.(string))
+			}
 		default:
 			log.Printf("Unknown type for field %s: %T", field, v)
 		}


### PR DESCRIPTION
This fixes a bug in which the alert name was the only thing entered in to the Jira issue body text.

This also fixes parsing of alert fields to properly grab the alert data from the formatted text fields.

REF: [OSD-21823](https://issues.redhat.com//browse/OSD-21823)

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
