### PR TITLE
 [OSD-21842] Adjust tests to match new reasons, summary fields

### DIFF
--- a/pkg/splunk/alert_test.go
+++ b/pkg/splunk/alert_test.go
@@ -21,28 +21,36 @@ func TestNewAlertDetails(t *testing.T) {
 			name: "Valid results should pass",
 			args: args{
 				result: SearchResult{
-					"alertname": "testAlertname",
-					"username":  "testUsername",
-					"group":     "testGroup",
-					"timestamp": "2021-01-01T00:00:00.GMT",
-					"clusterid": []string{"testClusterID1", "testClusterID2"},
-					"reason":    []string{"testReason1", "testReason2"},
+					"alertname":             "testAlertname",
+					"username":              "testUsername",
+					"group":                 "testGroup",
+					"timestamp":             "2021-01-01T00:00:00.GMT",
+					"clusterid":             []string{"testClusterID1", "testClusterID2"},
+					"cluster_text":          "testClusterID1, testClusterID2",
+					"elevated_summary":      []string{"DELETE secrets/cluster-version-operator-serving-cert (openshift-cluster-version) 200"},
+					"elevated_summary_text": "*COMMANDS*:\n - DELETE secrets/cluster-version-operator-serving-cert (openshift-cluster-version) 200",
+					"reason":                []string{"testReason1", "testReason2"},
+					"reason_text":           "*REASONS*:\n - testReason1\n - testReason2",
 				},
 			},
 			want: AlertDetails{
-				AlertName:  "testAlertname",
-				User:       "testUsername",
-				Group:      "testGroup",
-				Timestamp:  testTimestamp,
-				ClusterIDs: []string{"testClusterID1", "testClusterID2"},
-				Reasons:    []string{"testReason1", "testReason2"},
+				AlertName:           "testAlertname",
+				User:                "testUsername",
+				Group:               "testGroup",
+				Timestamp:           testTimestamp,
+				ClusterIDs:          []string{"testClusterID1", "testClusterID2"},
+				ClusterText:         "testClusterID1, testClusterID2",
+				ElevatedSummary:     []string{"DELETE secrets/cluster-version-operator-serving-cert (openshift-cluster-version) 200"},
+				ElevatedSummaryText: "*COMMANDS*:\n - DELETE secrets/cluster-version-operator-serving-cert (openshift-cluster-version) 200",
+				Reasons:             []string{"testReason1", "testReason2"},
+				ReasonsText:         "*REASONS*:\n - testReason1\n - testReason2",
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := NewAlertDetails(tt.args.result); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewAlertDetails() = %v, want %v", got, tt.want)
+				t.Errorf("%s\n\tgot:\n%+v\n\twant:\n%+v", tt.name, got, tt.want)
 			}
 		})
 	}
@@ -62,40 +70,56 @@ func TestAlert_Details(t *testing.T) {
 				SearchResults: SearchResults{
 					Results: []SearchResult{
 						{
-							"alertname": "testAlertname",
-							"username":  "testUsername",
-							"group":     "testGroup",
-							"timestamp": "2021-01-01T00:00:00.GMT",
-							"clusterid": []string{"testClusterID1", "testClusterID2"},
-							"reason":    []string{"testReason1", "testReason2"},
+							"alertname":             "testAlertname",
+							"username":              "testUsername",
+							"group":                 "testGroup",
+							"timestamp":             "2021-01-01T00:00:00.GMT",
+							"clusterid":             []string{"testClusterID1", "testClusterID2"},
+							"cluster_text":          "testClusterID1, testClusterID2",
+							"elevated_summary":      []string{"DELETE secrets/cluster-version-operator-serving-cert (openshift-cluster-version) 200"},
+							"elevated_summary_text": "*COMMANDS*:\n - DELETE secrets/cluster-version-operator-serving-cert (openshift-cluster-version) 200",
+							"reason":                []string{"testReason1", "testReason2"},
+							"reason_text":           "*REASONS*:\n - testReason1\n - testReason2",
 						},
 						{
-							"alertname": "testAlertname2",
-							"username":  "testUsername2",
-							"group":     "testGroup2",
-							"timestamp": "2021-01-01T00:00:00.GMT",
-							"clusterid": []string{"testClusterID3", "testClusterID4"},
-							"reason":    []string{"testReason3", "testReason4"},
+							"alertname":             "testAlertname",
+							"username":              "testUsername",
+							"group":                 "testGroup",
+							"timestamp":             "2021-01-01T00:00:00.GMT",
+							"clusterid":             []string{"testClusterID3", "testClusterID4"},
+							"cluster_text":          "testClusterID3, testClusterID4",
+							"elevated_summary":      []string{"PATCH secrets/cluster-version-operator-serving-cert (openshift-cluster-version) 200"},
+							"elevated_summary_text": "*COMMANDS*:\n - PATCH /cluster-version-operator-serving-cert (openshift-cluster-version) 200",
+							"reason":                []string{"testReason3", "testReason4"},
+							"reason_text":           "*REASONS*:\n - testReason3\n - testReason4",
 						},
 					},
 				},
 			},
 			want: []AlertDetails{
 				{
-					AlertName:  "testAlertname",
-					User:       "testUsername",
-					Group:      "testGroup",
-					Timestamp:  testTimestamp,
-					ClusterIDs: []string{"testClusterID1", "testClusterID2"},
-					Reasons:    []string{"testReason1", "testReason2"},
+					AlertName:           "testAlertname",
+					User:                "testUsername",
+					Group:               "testGroup",
+					Timestamp:           testTimestamp,
+					ClusterIDs:          []string{"testClusterID1", "testClusterID2"},
+					ClusterText:         "testClusterID1, testClusterID2",
+					ElevatedSummary:     []string{"DELETE secrets/cluster-version-operator-serving-cert (openshift-cluster-version) 200"},
+					ElevatedSummaryText: "*COMMANDS*:\n - DELETE secrets/cluster-version-operator-serving-cert (openshift-cluster-version) 200",
+					Reasons:             []string{"testReason1", "testReason2"},
+					ReasonsText:         "*REASONS*:\n - testReason1\n - testReason2",
 				},
 				{
-					AlertName:  "testAlertname2",
-					User:       "testUsername2",
-					Group:      "testGroup2",
-					Timestamp:  testTimestamp,
-					ClusterIDs: []string{"testClusterID3", "testClusterID4"},
-					Reasons:    []string{"testReason3", "testReason4"},
+					AlertName:           "testAlertname",
+					User:                "testUsername",
+					Group:               "testGroup",
+					Timestamp:           testTimestamp,
+					ClusterIDs:          []string{"testClusterID3", "testClusterID4"},
+					ClusterText:         "testClusterID3, testClusterID4",
+					ElevatedSummary:     []string{"PATCH secrets/cluster-version-operator-serving-cert (openshift-cluster-version) 200"},
+					ElevatedSummaryText: "*COMMANDS*:\n - PATCH /cluster-version-operator-serving-cert (openshift-cluster-version) 200",
+					Reasons:             []string{"testReason3", "testReason4"},
+					ReasonsText:         "*REASONS*:\n - testReason3\n - testReason4",
 				},
 			},
 		},
@@ -103,7 +127,7 @@ func TestAlert_Details(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.w.Details(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Alert.Details() = %v, want %v", got, tt.want)
+				t.Errorf("%s\n\tgot:\n%+v\n\twant:\n%+v", tt.name, got, tt.want)
 			}
 		})
 	}
@@ -170,7 +194,7 @@ func TestAlertDetails_Valid(t *testing.T) {
 			w: AlertDetails{
 				AlertName:  "testAlertname",
 				User:       "testUsername",
-				Group:      "testGroup",
+				Group:      "testGroups",
 				Timestamp:  testTimestamp,
 				ClusterIDs: []string{},
 				Reasons:    []string{"testReason1", "testReason2"},
@@ -181,7 +205,7 @@ func TestAlertDetails_Valid(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.w.Valid(); got != tt.want {
-				t.Errorf("AlertDetails.Valid() = %v, want %v", got, tt.want)
+				t.Errorf("%s\n\tgot:\n%+v\n\twant:\n%+v", tt.name, got, tt.want)
 			}
 		})
 	}

--- a/pkg/splunk/splunk_test.go
+++ b/pkg/splunk/splunk_test.go
@@ -32,12 +32,15 @@ import (
 const TEST_SEARCH_API_RESPONSE string = `{"preview":false,"init_offset":0,"messages":[],"fields":[{"name":"_time"},{"name":"alertname","type":"str"},{"name":"clusterid","type":"str"},{"name":"group","type":"str"},{"name":"timestamp","type":"str"},{"name":"username","type":"str"}],"results":[{"_time":"2023-08-27T02:25:00.000+10:00","alertname":"TestAlert","clusterid":"testcluster","group":"testgroup","timestamp":"2023-08-27T02:25:01.GMT","username":"testuser"}], "highlighted":{}}`
 
 var EXPECTED_ALERT_DETAILS = []AlertDetails{{
-	AlertName:  string("TestAlert"),
-	User:       "testuser",
-	Group:      "testgroup",
-	Timestamp:  time.Date(2023, 8, 27, 02, 25, 1, 0, time.UTC),
-	ClusterIDs: []string{"testcluster"},
-	Reasons:    []string{},
+	AlertName:           string("TestAlert"),
+	User:                "testuser",
+	Group:               "testgroup",
+	Timestamp:           time.Date(2023, 8, 27, 02, 25, 1, 0, time.UTC),
+	ClusterIDs:          []string{"testcluster"},
+	ElevatedSummary:     []string{},
+	ElevatedSummaryText: "",
+	Reasons:             []string{},
+	ReasonsText:         "",
 }}
 
 func TestMain(m *testing.M) {
@@ -71,7 +74,7 @@ func TestSplunkServer_RetrieveSearchFromAlert(t *testing.T) {
 		want         []AlertDetails
 		wantErr      bool
 	}{{
-		"test",
+		"test1",
 		*splunkserver,
 		args{"test"},
 		EXPECTED_ALERT_DETAILS,
@@ -86,11 +89,11 @@ func TestSplunkServer_RetrieveSearchFromAlert(t *testing.T) {
 			got, err := tt.splunkserver.RetrieveSearchFromAlert(tt.args.sid)
 			log.Println(got.Details())
 			if (err != nil) != tt.wantErr {
-				t.Errorf("SplunkServer.RetrieveSearchFromAlert() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("%s\n\tgot:\n%+v\n\twant error:\n%+v", tt.name, err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got.Details(), tt.want) {
-				t.Errorf("SplunkServer.RetrieveSearchFromAlert() = %v, want %v", got.Details(), tt.want)
+				t.Errorf("%s\n\tgot:\n%+v\n\twant:\n%+v", tt.name, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
    This adjusts the tests for Splunk alerts and alert retrieval to match
    the new fields in the parsing functions.
    
    Fixes OSD-21842
    
    Signed-off-by: Chris Collins <collins.christopher@gmail.com>
