### PR TITLE
fix replicas

### DIFF
--- a/deploy/compliance-audit-router.yml
+++ b/deploy/compliance-audit-router.yml
@@ -76,7 +76,7 @@ objects:
       labels:
         app: compliance-audit-router
     spec:
-      replicas: ${REPLICAS}
+      replicas: ${{REPLICAS}}
       selector:
         matchLabels:
           app: compliance-audit-router


### PR DESCRIPTION
fixes the following error when applying the resources:
```
Error from server (BadRequest): error when creating "STDIN": Deployment in version "v1" cannot be handled as a Deployment: json: cannot unmarshal string into Go struct field DeploymentSpec.spec.replicas of type int32
```