### PR TITLE
Remove restartPolicy from deployment

### DIFF
--- a/deploy/compliance-audit-router.yml
+++ b/deploy/compliance-audit-router.yml
@@ -111,7 +111,6 @@ objects:
                   memory: ${REQUESTS_MEM}
                 limits:
                   memory: ${LIMITS_MEM}
-              restartPolicy: Always
   - apiVersion: apps/v1
     kind: Service
     metadata:


### PR DESCRIPTION
Remove restartPolicy from deployment because it is not supported by App-Interface on
non-init containers.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
