### PR TITLE
Fix service .spec indent

### DIFF
--- a/deploy/compliance-audit-router.yml
+++ b/deploy/compliance-audit-router.yml
@@ -117,10 +117,10 @@ objects:
       name: compliance-audit-router
       labels:
         app: compliance-audit-router
-      spec:
-        selector:
-          app: compliance-audit-router
-        ports:
-          - protocol: TCP
-            port: ${LISTEN_PORT}
-            targetPort: ${LISTEN_PORT}
+    spec:
+      selector:
+        app: compliance-audit-router
+      ports:
+        - protocol: TCP
+          port: ${LISTEN_PORT}
+          targetPort: ${LISTEN_PORT}


### PR DESCRIPTION
The .spec section of the service in the deploy template was indented too
far, causing a parse error in App-Interface.  This "outdents" it to the
proper level.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
