### PR TITLE
Fix api version for service in deployment template

### DIFF
--- a/deploy/compliance-audit-router.yml
+++ b/deploy/compliance-audit-router.yml
@@ -111,7 +111,7 @@ objects:
                   memory: ${REQUESTS_MEM}
                 limits:
                   memory: ${LIMITS_MEM}
-  - apiVersion: apps/v1
+  - apiVersion: core/v1
     kind: Service
     metadata:
       name: compliance-audit-router


### PR DESCRIPTION
The apiVersion field for the service in the deployment template should
be `core/v1`, not `apps/v1`.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
