### PR TITLE
Adjust service apiVersion to v1

### DIFF
--- a/deploy/compliance-audit-router.yml
+++ b/deploy/compliance-audit-router.yml
@@ -116,7 +116,7 @@ objects:
                   memory: ${REQUESTS_MEM}
                 limits:
                   memory: ${LIMITS_MEM}
-  - apiVersion: core/v1
+  - apiVersion: v1
     kind: Service
     metadata:
       name: compliance-audit-router


### PR DESCRIPTION
Apparenlty `core/v1` is not required for describing a K8S service
apiVersion, and `v1` is correct.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
