### PR TITLE
Change $LISTEN_PORT variable to an integer

### DIFF
--- a/deploy/compliance-audit-router.yml
+++ b/deploy/compliance-audit-router.yml
@@ -54,7 +54,7 @@ parameters:
     required: false
   - name: "LISTEN_PORT"
     displayName: "Port to listen on"
-    value: "8080"
+    value: 8080
     required: false
   - name: "DRYRUN"
     displayName: "Dry-run mode"


### PR DESCRIPTION
Reverting the deployment template `LISTEN_PORT` variable back to an
integer rather than a string.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>

