### PR TITLE
Add quotes for parameter variable

### DIFF
--- a/deploy/compliance-audit-router.yml
+++ b/deploy/compliance-audit-router.yml
@@ -54,7 +54,7 @@ parameters:
     required: false
   - name: "LISTEN_PORT"
     displayName: "Port to listen on"
-    value: 8080
+    value: "8080"
     required: false
   - name: "DRYRUN"
     displayName: "Dry-run mode"
@@ -127,5 +127,5 @@ objects:
         app: compliance-audit-router
       ports:
         - protocol: TCP
-          port: ${LISTEN_PORT}
-          targetPort: ${LISTEN_PORT}
+          port: "${{LISTEN_PORT}}"
+          targetPort: "${{LISTEN_PORT}}"


### PR DESCRIPTION
Turns out the template requires int values to be quoted in both the
parameter and around the referenced variable in the template, but are
then re-parsed properly as int when the template is processed.

I belive this is finally being parsed correctly:

```
oc process --parameters -f deploy/compliance-audit-router.yml
NAME                     DESCRIPTION         GENERATOR           VALUE
IMAGE_REGISTRY                                                   quay.io
IMAGE_REPOSITORY                                                 app-sre
IMAGE_NAME                                                       compliance-audit-router
IMAGE_TAG                                                        latest
IMAGE_PULL_SECRET                                                quay.io
JIRA_SECRET_REF_KEY
SPLUNK_SECRET_REF_KEY
JIRA_SECRET_REF_NAME
SPLUNK_SECRET_REF_NAME
REPLICAS                                                         2
REQUESTS_CPU                                                     300m
REQUESTS_MEM                                                     2Gi
LIMITS_MEM                                                       2Gi
LISTEN_PORT                                                      8080
DRYRUN                                                           true
VERBOSE                                                          true
ROUTE_HOSTNAME
ROUTE_CLUSTER_DOMAIN
```

Signed-off-by: Chris Collins <collins.christopher@gmail.com>

