### PR TITLE
Quote ints in deploy template

### DIFF
--- a/deploy/compliance-audit-router.yml
+++ b/deploy/compliance-audit-router.yml
@@ -113,19 +113,19 @@ objects:
                 httpGet:
                   path: "/healthz"
                   port: "${{LISTEN_PORT}}"
-                initialDelaySeconds: 5
-                periodSeconds: 5
+                initialDelaySeconds: "5"
+                periodSeconds: "5"
               readinessProbe:
                 httpGet:
                   path: "/healthz"
                   port: "${{LISTEN_PORT}}"
-                initialDelaySeconds: 5
-                periodSeconds: 5
+                initialDelaySeconds: "5"
+                periodSeconds: "5"
           imagePullSecrets:
             - ${IMAGE_PULL_SECRET}
       replicas: ${{REPLICAS}}
-      revisionhistoryLimit: 3
-      progressDeadlineSeconds: 300
+      revisionhistoryLimit: "3"
+      progressDeadlineSeconds: "300"
   - apiVersion: v1
     kind: Service
     metadata:


### PR DESCRIPTION
The integers in the deploy template should be quoted to allow them to be
parsed properly by the template.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>