### PR TITLE
Fix license Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,4 +70,4 @@ list:
 # `go install github.com/google/addlicense@latest`
 .PHONY: license
 license:
-	@addlicense -c "Red Hat, Inc."  -l apache -v -y 2021-2024 .*go **/*.go **/**/*.go
+	@addlicense -c "Red Hat, Inc."  -l apache -v -y 2021-2024  **/*.go **/**/*.go


### PR DESCRIPTION
Removes the search for go files in the root of the repo by the `make
license` target, as none exist, and it throws an error otherwise.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
