### PR TITLE
Add a note about metric path registration

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -61,6 +61,8 @@ func main() {
 	log.Printf("initializing routes")
 	listeners.InitRoutes(r)
 
+	// Metrics registration exposes Prometheus metrics on /metrics
+	// NOTE: This does not use a go-chi route but is logged.
 	log.Printf("registering metrics")
 	metrics.RegisterMetrics()
 


### PR DESCRIPTION
Adds a comment to the metric registration to remind that the /metric
path is handled by the registration, and not the go-chi initialized
routes.

ie: /metrics will be initialized even though it isn't  one of the go-chi
listeners

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
