### PR TITLE
Continue in dry-run mode even if config is invalid

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -182,9 +182,13 @@ func LoadConfig() {
 		panic(err)
 	}
 
-	if !AppConfig.Valid() {
+	if !AppConfig.Valid() && !AppConfig.DryRun {
 		// If the config is invalid, log the errors and exit right away
 		log.Fatal("FATAL: configuration invalid - exiting")
+	} else if !AppConfig.Valid() && AppConfig.DryRun {
+		log.Print("WARN: configuration invalid - continuing in dry-run mode")
+	} else {
+		log.Print("INFO: configuration valid")
 	}
 }
 


### PR DESCRIPTION
If `CAR_DRYRUN=true` is specified, allow the app to continue startup even if
the configuration is invalid, and continue running in dry-run mode for
troubleshooting.

If `CAR_DRYRUN=false` or somehow unset (it should default to `true`),
then an invalid config will continue to log and immediately exit.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
